### PR TITLE
Mention commande /help + corrections victoire [Mineur]

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -37,7 +37,7 @@ var commands = {
   victory: {
     nb: 1,
     fn: function(player, args) {
-      player.room.gameplay.endGame(args[0]);
+      player.room.gameplay.endGame("<span class='glyphicon glyphicon-star'></span> "+args[0]);
     }
   },
   role: {

--- a/lib/victory.js
+++ b/lib/victory.js
@@ -28,7 +28,7 @@ module.exports = {
         this.endGame("<span class='glyphicon glyphicon-star'></span> Les citoyens ont réussi à repousser la Mafia !");
         return true;
       } else if(nbVillagers <= 1) {
-        this.endGame("<span class='glyphicon glyphicon-star'></span> La Mafia a réussi a contrôler le village !");
+        this.endGame("<span class='glyphicon glyphicon-star'></span> La Mafia a réussi à contrôler le village !");
         return true;
       }
 

--- a/roles/index.js
+++ b/roles/index.js
@@ -65,7 +65,7 @@ module.exports = {
       gamemaster.setChannel("general", null);
       gamemaster.setRole("gamemaster", require("./gamemaster")(room));
       gamemaster.canonicalRole = "<span class='label label-success'>Maître du Jeu</span>";
-      gamemaster.emit("setGameInfo", "Vous êtes <strong>Maître du Jeu</strong>. Bon courage ;)");
+      gamemaster.emit("setGameInfo", "Vous êtes <strong>Maître du Jeu</strong>. Tapez /help pour obtenir de l'aide sur les commandes. Bon courage ;)");
     }
 
     // Affect roles


### PR DESCRIPTION
- Mention de la commande /help pour le MDJ, en haut à gauche.
- Ajout de l'icône étoile lorsque le MDJ déclenche la victoire avec /victory.
- Correction d'une faute d'orthographe quand la Mafia gagne la partie.
