### PR TITLE
Delete from night message players who have used their power

### DIFF
--- a/roles/dentist.js
+++ b/roles/dentist.js
@@ -29,7 +29,7 @@ module.exports = function() {
           choice.player.canTalk = 1;
             
           player.room.message("<span class='mafia-stage-action mafia-role-action'><span class='glyphicon glyphicon-exclamation-sign'></span> Un dentiste a oublié " + funInstrument[GET_RANDOM(0, funInstrument.length-1)] + " dans la bouche de " + choice.username + "</span>");
-          player.roles.dentist.night = null;
+          player.roles.dentist.night = false;
         }
       }
     },

--- a/roles/dentist.js
+++ b/roles/dentist.js
@@ -5,6 +5,7 @@ module.exports = function() {
     name: "Dentiste",
     desc: "Vous pouvez interdire à une personne de parler au prochain tour <strong>une fois par partie</strong>. Vous devez aider les villageois à repousser la Mafia...",
     side: "village",
+    night: true,
 
     actions: {
       mute: {
@@ -28,6 +29,7 @@ module.exports = function() {
           choice.player.canTalk = 1;
             
           player.room.message("<span class='mafia-stage-action mafia-role-action'><span class='glyphicon glyphicon-exclamation-sign'></span> Un dentiste a oublié " + funInstrument[GET_RANDOM(0, funInstrument.length-1)] + " dans la bouche de " + choice.username + "</span>");
+          player.roles.dentist.night = null;
         }
       }
     },

--- a/roles/rescuer.js
+++ b/roles/rescuer.js
@@ -31,7 +31,6 @@ module.exports = function() {
           player.rescuerHasPlayed = true;
           player.sendAvailableActions();
           player.message("<span class='mafia-stage-action mafia-role-action'><span class='glyphicon glyphicon-heart-empty'></span> "+ victim.username +" a été sauvé d'une mort affreuse</span>");
-          player.roles.rescuer.night = null;
         }
       }
     },

--- a/roles/rescuer.js
+++ b/roles/rescuer.js
@@ -31,6 +31,7 @@ module.exports = function() {
           player.rescuerHasPlayed = true;
           player.sendAvailableActions();
           player.message("<span class='mafia-stage-action mafia-role-action'><span class='glyphicon glyphicon-heart-empty'></span> "+ victim.username +" a été sauvé d'une mort affreuse</span>");
+          player.roles.rescuer.night = null;
         }
       }
     },

--- a/roles/vigilant.js
+++ b/roles/vigilant.js
@@ -23,7 +23,7 @@ module.exports = function() {
           choice.player.pendingDeath.push({type: "vigilant"});
           player.sendAvailableActions();
           player.message("<span class='mafia-stage-action mafia-role-action'><span class='glyphicon glyphicon-screenshot'></span> Vous avez décidé d'assassiner "+ choice.username +" cette nuit</span>");
-          player.roles.vigilant.night = null;
+          player.roles.vigilant.night = false;
         }
       }
     },

--- a/roles/vigilant.js
+++ b/roles/vigilant.js
@@ -23,7 +23,7 @@ module.exports = function() {
           choice.player.pendingDeath.push({type: "vigilant"});
           player.sendAvailableActions();
           player.message("<span class='mafia-stage-action mafia-role-action'><span class='glyphicon glyphicon-screenshot'></span> Vous avez décidé d'assassiner "+ choice.username +" cette nuit</span>");
-
+          player.roles.vigilant.night = null;
         }
       }
     },


### PR DESCRIPTION
Retire de l'activité nocturne les joueurs à pouvoir unique qui l'ont déjà utilisé.

Ca concerne le Secouriste, Vigile et Dentiste.

On met simplement `night` à `null` quand le pouvoir est utilisé.
